### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Build APK
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/APPSDELIVERY/RotinaNoTrilho/security/code-scanning/1](https://github.com/APPSDELIVERY/RotinaNoTrilho/security/code-scanning/1)

To fix the issue, explicitly set `permissions` for the workflow or the specific job so that the `GITHUB_TOKEN` follows least-privilege. This workflow checks out code and uploads artifacts; `actions/checkout` only needs `contents: read`, and `actions/upload-artifact` does not use `GITHUB_TOKEN` for repo writes. Therefore, `contents: read` is a suitable minimal permission.

The best fix without changing existing functionality is to add a `permissions` block at the root of the workflow (applies to all jobs) or under the `build` job. Following CodeQL’s guidance and keeping it simple, we add:

```yaml
permissions:
  contents: read
```

near the top of `.github/workflows/main.yml`, between the `name:` and `on:` keys. No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
